### PR TITLE
Fix: #102. Introduced logic to warn if more than one .ttl files found

### DIFF
--- a/.github/workflows/asset-csv-generation.yml
+++ b/.github/workflows/asset-csv-generation.yml
@@ -38,7 +38,7 @@ env:
   PYTHON_VERSION: '3.14'
   SOURCE_REF: ${{ github.event.pull_request.head.sha || github.sha
     }}
-  CHECKOUT_REF: EricaCandido-102
+  CHECKOUT_REF: assets
   VOCABULARY_DIR: 'assets/controlled-vocabularies'
 jobs:
   # Detect which assets changed in this push

--- a/assets/controlled-vocabularies/ateco-2007-2022/ateco-2007-2022.frame.yamlld
+++ b/assets/controlled-vocabularies/ateco-2007-2022/ateco-2007-2022.frame.yamlld
@@ -1,0 +1,82 @@
+---
+#
+# Content-Type: application/ld+yaml; profile="http://www.w3.org/ns/json-ld#frame"
+#
+
+"@context": &jsonld_context
+  "@base": "https://w3id.org/italia/stat/controlled-vocabulary/economy/ateco-2007-2022/"
+  "@vocab": "https://w3id.org/italia/stat/controlled-vocabulary/economy/ateco-2007-2022/"
+
+  dct: http://purl.org/dc/terms/
+  skos: http://www.w3.org/2004/02/skos/core#
+  xkos: http://rdf-vocabulary.ddialliance.org/xkos#
+  clvapit: https://w3id.org/italia/onto/CLV/
+  xsd: "http://www.w3.org/2001/XMLSchema#"
+  covapit: https://w3id.org/italia/onto/COV/
+
+  # Fields
+  url: "@id"
+  id:
+    "@id": skos:notation
+
+  # Localize labels
+  label:
+    "@id": skos:prefLabel
+    "@language": it
+  label_it:
+    "@id": skos:prefLabel
+    "@language": it
+  label_en:
+    "@id": skos:prefLabel
+    "@language": en
+  label_de:
+    "@id": skos:prefLabel
+    "@language": de
+
+  # Hierarchy
+  parent:
+    "@id": skos:broader
+    "@container": "@set"
+    "@context":
+      url: "@id"
+
+  vocab:
+    "@id": skos:inScheme
+    "@container": "@set"
+    "@context":
+      url: "@id"
+
+  level:
+    "@id": clvapit:hasRankOrder
+    "@type": xsd:int
+
+"@explicit": true
+"@embed": "@never"
+"@omitDefault": true
+"@requireAll": true
+
+"@type":
+  - &jsonld_type "covapit:PrivateOrgActivityType"
+
+url: {}
+id: {}
+label_it: {}
+label_en: {}
+label_de: {}
+label:
+  "@language": ["it", "en", "de"]
+  "@value": {}
+level: {}
+
+vocab:
+- url: https://w3id.org/italia/stat/controlled-vocabulary/economy/ateco-2007-2022
+  "@explicit": true
+  "@embed": "@never"
+
+parent:
+- url: {}
+  id: {}
+  "@embed": "@always"
+  "@explicit": true
+  "@default": "@null"
+  "@requireAll": false


### PR DESCRIPTION
**Improvements in asset discovery**
This update enhances the detect-changes job by introducing a more robust asset discovery mechanism.
The workflow now:

- Identifies only directories containing exactly one .ttl file

- Skips directories with multiple TTL files and emits a warning

- Ensures the matrix receives only valid asset paths
- Shows a warning if more than 1 .ttl file is found into the directory. 

Test example:
- added a duplicated .ttl in agente-causale directory
- https://github.com/par-tec/dati-semantic-csv-apis/actions/runs/23349992678/job/67925743309?pr=103
Look into detect changed asset job, you can find the warning at line 80.

**Improvements in frame file validation**

- Both ci-pre-tabular and ci-tabular now include a robust check for .frame.yamlld files:

- If a frame file exists → the workflow proceeds with metadata and CSV generation

- If no frame file is found → a clear warning is emitted and the asset is skipped

Test example:
-removed ateco-2007-2022.frame.yamlld
-https://github.com/par-tec/dati-semantic-csv-apis/actions/runs/23352800027/job/67935781363?pr=103
Look at the steps Warn missing frame into ci-pre-tabular and ci-tabular.