### PR TITLE
Fix: #103. Introduced python script to download last valid artifact and fixed formatting by pre-commit

### DIFF
--- a/.github/scripts/fetch_artifact.py
+++ b/.github/scripts/fetch_artifact.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import os
+import sys
+import requests
+
+REPO = "par-tec/dati-semantic-csv-apis"
+WORKFLOW_NAME = "Test"
+ARTIFACT_NAME = "cli-binary"
+
+token = os.environ.get("GH_TOKEN")
+if not token:
+    print("Missing GH_TOKEN environment variable", file=sys.stderr)
+    sys.exit(1)
+
+headers = {"Authorization": f"Bearer {token}"}
+
+
+def get_runs():
+    url = f"https://api.github.com/repos/{REPO}/actions/runs"
+    r = requests.get(url, headers=headers)
+    r.raise_for_status()
+    data = r.json()
+    return [run["id"] for run in data["workflow_runs"] if run["name"] == WORKFLOW_NAME]
+
+
+def get_artifact_url(run_id):
+    url = f"https://api.github.com/repos/{REPO}/actions/runs/{run_id}/artifacts"
+    r = requests.get(url, headers=headers)
+    r.raise_for_status()
+    artifacts = r.json().get("artifacts", [])
+    for a in artifacts:
+        if a["name"] == ARTIFACT_NAME and not a["expired"]:
+            return a["archive_download_url"]
+    return None
+
+
+def main():
+    runs = get_runs()
+    if not runs:
+        print(f"No runs found for workflow '{WORKFLOW_NAME}'", file=sys.stderr)
+        sys.exit(1)
+
+    for run_id in runs:
+        url = get_artifact_url(run_id)
+        if url:
+            print(url)
+            return
+
+    print(
+        f"No valid artifact '{ARTIFACT_NAME}' found in any recent run", file=sys.stderr
+    )
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/asset-csv-generation.yml
+++ b/.github/workflows/asset-csv-generation.yml
@@ -123,48 +123,26 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: ${{ env.PYTHON_VERSION }}
+    - name: Install Python dependencies
+      run: |
+        pip install requests
     - name: Download binary artifact
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -e
-        REPO="par-tec/dati-semantic-csv-apis"
-        echo "Fetching latest workflow run..."
-        
-        RUN_ID=$(curl -s \
-          -H "Authorization: Bearer ${GH_TOKEN}" \
-          https://api.github.com/repos/${REPO}/actions/runs \
-          | jq -r '
-            .workflow_runs
-            | map(select(.name=="Test"))
-            | first
-            | .id
-          ')
-  
-        echo "Latest run ID: ${RUN_ID}"
 
-        if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
-          echo "No run found for workflow Test"
-          exit 1
-        fi
+        echo "Fetching artifact URL via Python script..."
+        ARTIFACT_URL=$(python3 .github/scripts/fetch_artifact.py)
 
-        echo "Fetching artifacts..."
-
-        ARTIFACT_URL=$(curl -s \
-          -H "Authorization: Bearer ${GH_TOKEN}" \
-          https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}/artifacts \
-          | jq -r '.artifacts[]
-            | select(.name=="cli-binary")
-            | select(.expired==false)
-            | .archive_download_url')
-
-        echo "Artifact URL: ${ARTIFACT_URL}"
+        echo "Artifact URL: $ARTIFACT_URL"
 
         if [ -z "$ARTIFACT_URL" ] || [ "$ARTIFACT_URL" = "null" ]; then
-          echo "No artifact found in run ${RUN_ID}"
+          echo "No valid artifact found"
           exit 1
         fi
 
+        echo "Downloading artifact..."
         curl -L \
           -H "Authorization: Bearer ${GH_TOKEN}" \
           "${ARTIFACT_URL}" \
@@ -178,7 +156,6 @@ jobs:
         unzip /tmp/artifact.zip -d /usr/local/bin/
         chmod +x /usr/local/bin/schema_gov_it_tools.bin
         /usr/local/bin/schema_gov_it_tools.bin --version
-    
     - name: Debug matrix asset
       run: |
         echo "Processing directory: '${{ matrix.asset }}'"
@@ -288,47 +265,26 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: ${{ env.PYTHON_VERSION }}
+    - name: Install Python dependencies
+      run: |
+        pip install requests
     - name: Download binary artifact
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -e
-        REPO="par-tec/dati-semantic-csv-apis"
-        echo "Fetching latest workflow run..."
-        
-        RUN_ID=$(curl -s \
-          -H "Authorization: Bearer ${GH_TOKEN}" \
-          https://api.github.com/repos/${REPO}/actions/runs \
-          | jq -r '
-            .workflow_runs
-            | map(select(.name=="Test"))
-            | first
-            | .id
-          ')
 
-        echo "Latest run ID: ${RUN_ID}"
+        echo "Fetching artifact URL via Python script..."
+        ARTIFACT_URL=$(python3 .github/scripts/fetch_artifact.py)
 
-        if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
-          echo "No run found for workflow Test"
-          exit 1
-        fi        
-
-        echo "Fetching artifacts..."
-
-        ARTIFACT_URL=$(curl -s \
-          -H "Authorization: Bearer ${GH_TOKEN}" \
-          https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}/artifacts \
-          | jq -r '.artifacts[]
-            | select(.name=="cli-binary")
-            | select(.expired==false)
-            | .archive_download_url')
-
-        echo "Artifact URL: ${ARTIFACT_URL}"
+        echo "Artifact URL: $ARTIFACT_URL"
 
         if [ -z "$ARTIFACT_URL" ] || [ "$ARTIFACT_URL" = "null" ]; then
-          echo "No artifact found in run ${RUN_ID}"
+          echo "No valid artifact found"
           exit 1
         fi
+
+        echo "Downloading artifact..."
         curl -L \
           -H "Authorization: Bearer ${GH_TOKEN}" \
           "${ARTIFACT_URL}" \
@@ -338,7 +294,7 @@ jobs:
           echo "Artifact download failed"
           exit 1
         fi
-        
+
         unzip /tmp/artifact.zip -d /usr/local/bin/
         chmod +x /usr/local/bin/schema_gov_it_tools.bin
         /usr/local/bin/schema_gov_it_tools.bin --version
@@ -380,7 +336,9 @@ jobs:
       run: |
         echo "::warning title=Missing frame file::No frame file found for asset '${{ matrix.asset }}'. This asset will be skipped."
     - name: Generate and validate CSV
-      if: steps.check-datapackage.outputs.exists == 'true' && steps.check-frame.outputs.exists == 'true' && !contains(matrix.asset, 'theme-subtheme-mapping')
+      if: steps.check-datapackage.outputs.exists == 'true' &&
+        steps.check-frame.outputs.exists == 'true' && !contains(matrix.asset,
+        'theme-subtheme-mapping')
       working-directory: >-
         ${{ matrix.asset }}
       run: |
@@ -413,7 +371,8 @@ jobs:
         MATRIX_ASSET: ${{ matrix.asset }}
     - name: Check for CSV files
       id: check-csv
-      if: steps.check-datapackage.outputs.exists == 'true' && !contains(matrix.asset, 'theme-subtheme-mapping')
+      if: steps.check-datapackage.outputs.exists == 'true' &&
+        !contains(matrix.asset, 'theme-subtheme-mapping')
       working-directory: >-
         ${{ matrix.asset }}
       run: |


### PR DESCRIPTION
## This PR

See #103 

- Added a Python script that scans all workflow runs of the Test workflow and selects the first valid, non‑expired cli-binary artifact.
-  Ensured the CI now downloads only valid artifacts and fails gracefully when none are available.